### PR TITLE
add reservation for EIP when use Prepaid in Billing

### DIFF
--- a/eip/eip.go
+++ b/eip/eip.go
@@ -22,14 +22,18 @@ type Eip struct {
 	CreateTime      string          `json:"createTime"`
 	ExpireTime      string          `json:"expireTime"`
 }
+
 type Billing struct {
-	PaymentTiming string `json:"paymentTiming"`
-	BillingMethod string `json:"billingMethod"`
+	PaymentTiming string       `json:"paymentTiming"`
+	BillingMethod string       `json:"billingMethod"`
+	Reservation   *Reservation `json:"reservation"`
 }
+
 type Reservation struct {
 	ReservationLength   int    `json:"reservationLength"`
 	ReservationTimeUnit string `json:"reservationTimeUnit"`
 }
+
 type CreateEipArgs struct {
 	//  公网带宽，单位为Mbps。
 	// 对于prepay以及bandwidth类型的EIP，限制为为1~200之间的整数，


### PR DESCRIPTION
This PR:
Add reservation for EIP when use Prepaid in Billing.
Refer: https://cloud.baidu.com/doc/EIP/API/27.5CEIP.E7.9B.B8.E5.85.B3.E6.8E.A5.E5.8F.A3.html#.E7.94.B3.E8.AF.B7EIP